### PR TITLE
feat: update git with backports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/stretch-arm64/Dockerfile
+++ b/stretch-arm64/Dockerfile
@@ -1,5 +1,9 @@
 FROM debian:stretch
 
+# add backports
+RUN echo "deb http://deb.debian.org/debian stretch-backports main" | tee -a /etc/apt/sources.list
+RUN apt-get update && apt-get install -y -t stretch-backports git git-man
+
 RUN dpkg --add-architecture arm64
 RUN apt-get update && apt-get install -y --no-install-recommends \
   crossbuild-essential-arm64 \

--- a/stretch-armhf/Dockerfile
+++ b/stretch-armhf/Dockerfile
@@ -1,5 +1,9 @@
 FROM debian:stretch
 
+# add backports
+RUN echo "deb http://deb.debian.org/debian stretch-backports main" | tee -a /etc/apt/sources.list
+RUN apt-get update && apt-get install -y -t stretch-backports git git-man
+
 RUN dpkg --add-architecture armhf
 RUN apt-get update && apt-get install -y --no-install-recommends \
   crossbuild-essential-armhf \


### PR DESCRIPTION
This PR is updating `git` so that `actions/checkout@v2` uses `git` (require >=2.18) instead of using REST API (https://github.com/actions/checkout/issues/126#issuecomment-570288731)

It's  part of a refactoring so that the workflows don't re-publish existing binaries (for https://github.com/VSCodium/vscodium/issues/828 and https://github.com/VSCodium/vscodium/issues/847).

The change for `runs-on` is due to: https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/