### PR TITLE
feat: add loong64 devtoolset image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,12 +23,17 @@ jobs:
           - focal-x64
           - focal-devtoolset-ppc64le
           - focal-devtoolset-riscv64
+          - trixie-devtoolset-loong64
 
     steps:
       - uses: actions/checkout@v3
 
       - uses: docker/setup-qemu-action@v2
-        if: "!endsWith(matrix.arch, 'x64')"
+        if: "!endsWith(matrix.arch, 'x64') && !endsWith(matrix.arch, 'loong64')"
+
+      - name: Set up QEMU for Loong64
+        run: docker run --rm --privileged loongcr.lcpu.dev/multiarch/archlinux --reset -p yes
+        if: "endsWith(matrix.arch, 'loong64')"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/trixie-devtoolset-loong64/Dockerfile
+++ b/trixie-devtoolset-loong64/Dockerfile
@@ -1,0 +1,53 @@
+ARG REPO=loongarch64/debian
+ARG TAG=latest
+FROM ${REPO}:${TAG}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_VERSION="20.16.0"
+
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+    binutils \
+    build-essential \
+    # build-essential will offer gcc-14 and g++-14, which is overly new for us.
+    gcc-12 \
+    g++-12 \
+    git \
+    pkg-config \
+    fakeroot \
+    rpm \
+    sudo \
+    apt-transport-https \
+    ca-certificates \
+    libx11-dev \
+    libx11-xcb-dev \
+    libxkbfile-dev \
+    libsecret-1-dev \
+    libkrb5-dev \
+    libatomic1 \
+    curl \
+    gnupg \
+    unzip \
+    # VSCodium
+    jq
+
+# set gcc-12 and g++-12 as default (gcc doesn't support loong64 until 12.1)
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 1 && \
+  update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 1
+
+# set python3 as default
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
+  python --version
+
+# setup Node.js
+RUN curl -L -O https://unofficial-builds.nodejs.org/download/release/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-loong64.tar.gz && \
+    tar -xzf node-v${NODE_VERSION}-linux-loong64.tar.gz && \
+    cp -R node-v${NODE_VERSION}-linux-loong64/* /usr/local/ && \
+    rm -rf node-v${NODE_VERSION}-linux-loong64* && \
+    node --version
+
+# install yarn & node-gyp
+RUN npm install -g yarn node-gyp
+
+RUN mkdir -p /root/vscode
+WORKDIR /root/vscode


### PR DESCRIPTION
This PR introduces the devtoolset image for Loong64, a RISC-style ISA developed by Loongson.

The image uses Debian trixie SID because the ecosystem for the arch is quite immature.

Background: I am working on porting both VSCodium REH server and client to Loong64, and this PR is part of porting the server itself. Another PR to VSCodium repo for the server is coming soon. The build image for client will be introduced when the work on the client is done.